### PR TITLE
FIX revert removal of 'last logged in' column

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,5 +1,6 @@
 en:
   SilverStripe\SecurityReport\MemberReportExtension:
+    NEVER: Never
     NOGROUPS: 'Not in a Security Group'
     NOPERMISSIONS: 'No Permissions'
     UNKNOWN: Unknown

--- a/src/MemberReportExtension.php
+++ b/src/MemberReportExtension.php
@@ -3,6 +3,7 @@ namespace SilverStripe\SecurityReport;
 
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\LoginAttempt;
 use SilverStripe\Subsites\Model\Subsite;
 
 /**
@@ -11,6 +12,20 @@ use SilverStripe\Subsites\Model\Subsite;
  */
 class MemberReportExtension extends DataExtension
 {
+
+    /**
+     * Connect the link to LoginAttempt.
+     * This relationship is always defined (whether enabled or not),
+     * although only normally accessible from the `LoginAttempt` side.
+     * This is adding the reflection, as that it is also accessible
+     * from the `Member` side.
+     *
+     * @var array
+     * @config
+     */
+    private static $has_many = [
+        'LoginAttempts' => LoginAttempt::class
+    ];
     
     /**
      * Set cast of additional fields
@@ -22,6 +37,21 @@ class MemberReportExtension extends DataExtension
         'GroupsDescription' => 'Text',
         'PermissionsDescription' => 'Text'
     );
+
+    /**
+     * Retrieves the most recent successful LoginAttempt
+     *
+     * @return DBDatetime|string
+     */
+    public function getLastLoggedIn()
+    {
+        $lastTime = $this->owner->LoginAttempts()
+            ->filter('Status', 'Success')
+            ->sort('Created', 'DESC')
+            ->first();
+
+        return $lastTime ? $lastTime->dbObject('Created') : _t(__CLASS__ . '.NEVER', 'Never');
+    }
 
     /**
      * Builds a comma separated list of member group names for a given Member.

--- a/src/UserSecurityReport.php
+++ b/src/UserSecurityReport.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\Reports\Report;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
 use SilverStripe\SecurityReport\Forms\GridFieldExportReportButton;
 use SilverStripe\SecurityReport\Forms\GridFieldPrintReportButton;
 
@@ -33,6 +34,7 @@ class UserSecurityReport extends Report
         'Surname' => 'Surname',
         'Email' => 'Email',
         'Created' => 'Date Created',
+        'LastLoggedIn' => 'Last Logged In',
         'GroupsDescription' => 'Groups',
         'PermissionsDescription' => 'Permissions',
     );
@@ -70,7 +72,11 @@ class UserSecurityReport extends Report
      */
     public function columns()
     {
-        return self::config()->columns;
+        $columns = self::config()->columns;
+        if (!Security::config()->get('login_recording')) {
+            unset($columns['LastLoggedIn']);
+        }
+        return $columns;
     }
 
     /**

--- a/tests/UserSecurityReportTest.php
+++ b/tests/UserSecurityReportTest.php
@@ -2,8 +2,10 @@
 
 namespace SilverStripe\SecurityReport\Tests;
 
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\SecurityReport\MemberReportExtension;
 use SilverStripe\Reports\Report;
 use SilverStripe\Dev\SapphireTest;
@@ -80,5 +82,18 @@ class UserSecurityReportTest extends SapphireTest
         $member = $this->objFromFixture(Member::class, 'member-has-n-permissions');
         $perms = $member->PermissionsDescription;
         $this->assertEquals('Full administrative rights, Edit any page', $perms);
+    }
+
+    public function testLoginLoggingColumnShowsOnlyWhenApplicable()
+    {
+        $original = Config::inst()->get(Security::class, 'login_recording');
+
+        Config::modify()->set(Security::class, 'login_recording', true);
+        $this->assertContains('LastLoggedIn', array_keys($this->report->columns()));
+
+        Config::modify()->set(Security::class, 'login_recording', false);
+        $this->assertNotContains('LastLoggedIn', array_keys($this->report->columns()));
+
+        Config::modify()->set(Security::class, 'login_recording', $original);
     }
 }


### PR DESCRIPTION
This field is gone from member, however we can source the data from
Successful LoginAttempts. As this relies on this data capture to be
enabled, the change also conditionally includes the column, iff the
config setting to log logins is enabled.

Fixes #32 