### PR TITLE
FIX Remove "Login Attempts" tab from Member CMS fields

### DIFF
--- a/src/MemberReportExtension.php
+++ b/src/MemberReportExtension.php
@@ -2,6 +2,8 @@
 namespace SilverStripe\SecurityReport;
 
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\Group;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\LoginAttempt;
 use SilverStripe\Subsites\Model\Subsite;
@@ -12,21 +14,6 @@ use SilverStripe\Subsites\Model\Subsite;
  */
 class MemberReportExtension extends DataExtension
 {
-
-    /**
-     * Connect the link to LoginAttempt.
-     * This relationship is always defined (whether enabled or not),
-     * although only normally accessible from the `LoginAttempt` side.
-     * This is adding the reflection, as that it is also accessible
-     * from the `Member` side.
-     *
-     * @var array
-     * @config
-     */
-    private static $has_many = [
-        'LoginAttempts' => LoginAttempt::class
-    ];
-    
     /**
      * Set cast of additional fields
      *
@@ -45,12 +32,18 @@ class MemberReportExtension extends DataExtension
      */
     public function getLastLoggedIn()
     {
-        $lastTime = $this->owner->LoginAttempts()
-            ->filter('Status', 'Success')
+        $lastTime = LoginAttempt::get()
+            ->filter([
+                'MemberID' => $this->owner->ID,
+                'Status' => 'Success',
+            ])
             ->sort('Created', 'DESC')
             ->first();
 
-        return $lastTime ? $lastTime->dbObject('Created') : _t(__CLASS__ . '.NEVER', 'Never');
+        if ($lastTime) {
+            return $lastTime->dbObject('Created')->format(DBDatetime::ISO_DATETIME);
+        }
+        return _t(__CLASS__ . '.NEVER', 'Never');
     }
 
     /**
@@ -63,13 +56,14 @@ class MemberReportExtension extends DataExtension
         if (class_exists(Subsite::class)) {
             Subsite::disable_subsite_filter(true);
         }
-        
+
         // Get the member's groups, if any
         $groups = $this->owner->Groups();
         if ($groups->Count()) {
             // Collect the group names
             $groupNames = array();
             foreach ($groups as $group) {
+                /** @var Group $group */
                 $groupNames[] = html_entity_decode($group->getTreeTitle());
             }
             // return a csv string of the group names, sans-markup
@@ -78,13 +72,13 @@ class MemberReportExtension extends DataExtension
             // If no groups then return a status label
             $result = _t(__CLASS__ . '.NOGROUPS', 'Not in a Security Group');
         }
-        
+
         if (class_exists(Subsite::class)) {
             Subsite::disable_subsite_filter(false);
         }
         return $result;
     }
-    
+
     /**
      * Builds a comma separated list of human-readbale permissions for a given Member.
      *
@@ -95,11 +89,11 @@ class MemberReportExtension extends DataExtension
         if (class_exists(Subsite::class)) {
             Subsite::disable_subsite_filter(true);
         }
-        
+
         $permissionsUsr = Permission::permissions_for_member($this->owner->ID);
         $permissionsSrc = Permission::get_codes(true);
         sort($permissionsUsr);
-        
+
         $permissionNames = array();
         foreach ($permissionsUsr as $code) {
             $code = strtoupper($code);
@@ -116,7 +110,7 @@ class MemberReportExtension extends DataExtension
         $result = $permissionNames
             ? implode(', ', $permissionNames)
             : _t(__CLASS__ . '.NOPERMISSIONS', 'No Permissions');
-        
+
         if (class_exists(Subsite::class)) {
             Subsite::disable_subsite_filter(false);
         }

--- a/tests/UserSecurityReportTest.php
+++ b/tests/UserSecurityReportTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SecurityReport\Tests;
 
 use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
@@ -40,7 +41,7 @@ class UserSecurityReportTest extends SapphireTest
     /**
      * Utility method for all tests to use.
      *
-     * @return \ArrayList
+     * @return ArrayList
      * @todo pre-fill the report with fixture-defined users
      */
     protected function setUp()


### PR DESCRIPTION
Adding the relationship for Member -> LoginAttempt creates an automatically scaffolded CMS tab for Members, listing the ID of each login attempt.

This PR removes that and replaces the logic with a lookup using an ORM filter instead. Also adds a couple of missing PHPDoc imports.