### PR TITLE
FIX Move Subsite edit permissions column definition into config, now shows at end of list

### DIFF
--- a/_config/subsite.yml
+++ b/_config/subsite.yml
@@ -4,8 +4,8 @@ Only:
   moduleexists: silverstripe/subsites
 ---
 SilverStripe\SecurityReport\UserSecurityReport:
-  extensions:
-    - SilverStripe\SecurityReport\Subsites\SubsiteSecurityReport
+  columns:
+    SubsiteDescription: Subsites (edit permissions)
 
 SilverStripe\Security\Member:
   extensions:

--- a/src/Subsites/SubsiteSecurityReport.php
+++ b/src/Subsites/SubsiteSecurityReport.php
@@ -12,13 +12,4 @@ use SilverStripe\Core\Extension;
 class SubsiteSecurityReport extends Extension
 {
 
-    /**
-     * Columns in the report
-     *
-     * @var array
-     * @config
-     */
-    private static $columns = array(
-        'SubsiteDescription' => 'Subsites (edit permissions)',
-    );
 }


### PR DESCRIPTION
Since SilverStripe 4.x, the order of applying extensions and YAML config has changed from SilverStripe 3.x. Moving this config into YAML ensures that the column is appended rather than prepended.

Fixes #39