### PR TITLE
API SubsiteSecurityReport is now deprecated, please use YAML configuration instead

### DIFF
--- a/src/Subsites/SubsiteSecurityReport.php
+++ b/src/Subsites/SubsiteSecurityReport.php
@@ -7,6 +7,7 @@ use SilverStripe\Core\Extension;
 /**
  * User Security Report extension for Subsites
  *
+ * @deprecated 2.1.0 This extension will be removed in 3.0, configuration should be put in YAML instead
  * @author Damian Mooyman <damian@silverstripe.com>
  */
 class SubsiteSecurityReport extends Extension


### PR DESCRIPTION
Logic removed in #40, this deprecates the extension in the next minor version

Issue #39