### PR TITLE
Update for 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION="2.x-dev"
+    - COMPOSER_ROOT_VERSION="2.2.x-dev"
 
 matrix:
   include:


### PR DESCRIPTION
composer.json does not need changing
```
    "require": {
        "silverstripe/framework": "^4",
        "silverstripe/cms": "^4",
        "silverstripe/reports": "^4"
    },
```